### PR TITLE
daemonize to run as OS X background service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Spotify bot
 
-A very small script to allow Slack to control the Spotify app running on a Mac via a bot.
+A very small script to control Spotify from Slack, using a bot.
 
 ### Setup
 
@@ -14,21 +14,46 @@ Name your bot "Spotify" or whatever you like. Copy the key Slack gives you.
 
 Create a file named `bot_setup.js` and populate it with:
 
-```
+```javascript
 module.exports = {
   token: 'your slack bot token here',
-  channel: 'channel name (no #)' // optional for track updates - if you can't find the channel id just leave this out
+  channel: 'channel name (no #)' // optional, for posting track updates
 };
 ```
 
 #### Install the required dependencies
 
-`npm install`
+    npm install
 
 #### Boot up your new bot:
 
-`node spotifybot.js`
+    node spotifybot.js
 
 In Slack, invite the bot to a channel (`/invite @bot_name`) and now you can talk to it.
 
 Type `@bot_name help` to get a list of commands
+
+#### Keep your bot running as a background service:
+
+On OS X, background services are either LaunchAgents or LaunchDaemons.
+SpotifySlackBot can only run while a user is logged in, since it depends
+on the Spotify GUI app being open, so the appropriate type of service
+here is a LaunchAgent.
+
+First, edit `spotifybot.launchagent.plist` and change `BOT_HOME` to
+the **full path** of your bot's directory, e.g.
+`/Users/jm3/code/spotifyslackbot` or the like.
+
+Install the launchAgent by copying it to the required location:
+
+    cp spotifybot.launchagent.plist ~/Library/LaunchAgents/
+
+If you care about logging (and who doesn't), create two empty logfiles, owned by you:
+
+    sudo touch /var/log/spotify.slackbot.out.log /var/log/spotify.slackbot.err.log
+    sudo chown `whoami` /var/log/spotify.slackbot.out.log /var/log/spotify.slackbot.err.log
+
+Finally, launch your background service for the first time (it will now auto-start upon login)
+
+    launchctl load ~/Library/LaunchAgents/spotifybot.launchagent.plist
+

--- a/spotifybot.launchagent.plist
+++ b/spotifybot.launchagent.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>spotify.slackbot</string>
+
+    <key>WorkingDirectory</key>
+    <string>/BOT_HOME/</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/node</string>
+      <string>spotifybot.js</string>
+    </array>
+
+    <key>StandardOutPath</key>
+      <string>/var/log/spotify.slackbot.out.log</string>
+
+    <key>StandardErrorPath</key>
+      <string>/var/log/spotify.slackbot.err.log</string>
+
+    <key>RunAtLoad</key>
+      <true/>
+</dict>
+</plist>
+


### PR DESCRIPTION
Yo, I'm a fully autonomous background bot service now!

![bot](https://cloud.githubusercontent.com/assets/12213/14925234/4b2ce4a8-0dfb-11e6-938a-68e08180c3dd.png)

Added launchAgent plist and updated README with instructions.
